### PR TITLE
Initial fuzzing support and fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,4 +41,4 @@ log-error = []
 
 
 [patch.crates-io]
-flexiber = { git = "https://github.com/Nitrokey/flexiber", branch = "oath-authenticator" }
+flexiber = { git = "https://github.com/Nitrokey/flexiber", rev = "0.1.1.nitrokey" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ log-debug = []
 log-warn = []
 log-error = []
 
+
+[patch.crates-io]
+flexiber = { git = "https://github.com/Nitrokey/flexiber", branch = "oath-authenticator" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -44,3 +44,4 @@ doc = false
 
 [patch.crates-io]
 trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
+flexiber = { git = "https://github.com/Nitrokey/flexiber", branch = "oath-authenticator" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "oath-authenticator-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+apdu-dispatch = { version = "0.1",  optional = true }
+flexiber = { version = "0.1.0", features = ["derive", "heapless"] }
+heapless = "0.7"
+heapless-bytes = "0.3"
+hex-literal = "0.3"
+interchange = "0.2"
+iso7816 = "0.1"
+serde = { version = "1", default-features = false }
+trussed = { version = "0.1.0", features = ["virt", "verbose-tests"] }
+ctaphid-dispatch = { version = "0.1", optional = true }
+usbd-ctaphid = { git = "https://github.com/Nitrokey/nitrokey-3-firmware", optional = true }
+
+[dependencies.oath-authenticator]
+path = ".."
+
+[features]
+default = ["ctaphid-dispatch", "usbd-ctaphid", "apdu-dispatch"]
+
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false
+
+
+[patch.crates-io]
+trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -11,7 +11,7 @@ check:
 
 .PHONY: fuzz
 fuzz:
-	cargo +nightly fuzz run --jobs ${FUZZ_JOBS} fuzz_target_1 corpus -- -max_total_time=${FUZZ_DURATION}
+	nice cargo +nightly fuzz run --jobs ${FUZZ_JOBS} fuzz_target_1 corpus -- -max_total_time=${FUZZ_DURATION}
 
 .PHONY: fuzz-cov
 fuzz-cov:

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -16,7 +16,12 @@ fuzz:
 .PHONY: fuzz-cov
 fuzz-cov:
 	cargo +nightly fuzz coverage fuzz_target_1 corpus
-	llvm-cov show --format=html \
+	$(MAKE) fuzz-cov-show
+
+LLVMCOV=~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov
+.PHONY: fuzz-cov-show
+fuzz-cov-show:
+	$(LLVMCOV) show --format=html \
 		--instr-profile=coverage/fuzz_target_1/coverage.profdata \
 		 ${CARGO_TARGET_DIR}/x86_64-unknown-linux-gnu/release/fuzz_target_1 \
 		> fuzz_coverage.html

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -1,0 +1,32 @@
+# Copyright (C) 2022 Nitrokey GmbH
+# SPDX-License-Identifier: CC0-1.0
+
+FUZZ_DURATION?="0"
+FUZZ_JOBS?=$(shell nproc)
+.NOTPARALLEL:
+
+.PHONY: check
+check:
+	reuse lint
+
+.PHONY: fuzz
+fuzz:
+	cargo +nightly fuzz run --jobs ${FUZZ_JOBS} fuzz_target_1 corpus -- -max_total_time=${FUZZ_DURATION}
+
+.PHONY: fuzz-cov
+fuzz-cov:
+	cargo +nightly fuzz coverage fuzz_target_1 corpus
+	llvm-cov show --format=html \
+		--instr-profile=coverage/fuzz_target_1/coverage.profdata \
+		 ${CARGO_TARGET_DIR}/x86_64-unknown-linux-gnu/release/fuzz_target_1 \
+		> fuzz_coverage.html
+
+.PHONY: ci
+ci: check
+
+.PHONY: setup
+setup:
+	rustup component add clippy rustfmt && rustup toolchain install nightly
+	rustup component add llvm-tools-preview
+	cargo install cargo-tarpaulin cargo-fuzz --profile release
+	python3 -m pip install reuse

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,14 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    trussed::virt::with_ram_client("oath", move |client| {
+        let mut oath = oath_authenticator::Authenticator::<_>::new(client);
+        let mut response = heapless::Vec::<u8, { 3 * 1024 }>::new();
+
+        if let Ok(command) = iso7816::Command::<{ 10 * 255 }>::try_from(&data) {
+            oath.respond(&command, &mut response).ok();
+        }
+    })
+});

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -15,7 +15,7 @@ use trussed::{
     types::{KeyId, Location, PathBuf},
 };
 
-use crate::{command, Command, oath, state::{CommandState, State}};
+use crate::{assertfn, command, Command, oath, state::{CommandState, State}};
 use crate::command::VerifyCode;
 use crate::oath::Kind;
 
@@ -174,9 +174,9 @@ where
     fn inner_respond<const C: usize, const R: usize>(&mut self, command: &iso7816::Command<C>, reply: &mut Data<R>) -> Result
     {
         let class = command.class();
-        assert!(class.chain().last_or_only());
-        assert!(class.secure_messaging().none());
-        assert!(class.channel() == Some(0));
+        assertfn(class.chain().last_or_only(), Status::CommandChainingNotSupported)?;
+        assertfn(class.secure_messaging().none(), Status::SecureMessagingNotSupported)?;
+        assertfn(class.channel() == Some(0), Status::ClassNotSupported)?;
 
         // parse Iso7816Command as PivCommand
         let command: Command = command.try_into()?;

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -93,6 +93,10 @@ pub struct ChallengingAnswerToSelect {
     // instead of '74 00', as with the tagged/Option derivation.
     #[tlv(simple = "0x74")] // Tag::Challenge
     challenge: [u8; 8],
+
+    #[tlv(simple = "0x7b")] // Tag::Algorithm
+    // algorithm: oath::Algorithm,
+    algorithm: [u8; 1],
 }
 
 impl AnswerToSelect {
@@ -114,6 +118,8 @@ impl AnswerToSelect {
             version: self.version,
             salt: self.salt,
             challenge: challenge,
+            // algorithm: oath::Algorithm::Sha1  // TODO set proper algo
+            algorithm: [0x01]  // TODO set proper algo
         }
     }
 }

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -758,6 +758,7 @@ where
             None => {
                 // Failed verification
                 self.wink_bad();
+                self.delay_on_failure();
                 return Err(Status::VerificationFailed);
             }
             Some(val) => val
@@ -836,6 +837,12 @@ where
     fn wink_good(&mut self) {
         // TODO blink green LED for 10 seconds, highest priority
         syscall!(self.trussed.wink(Duration::from_secs(10)));
+    }
+
+    fn delay_on_failure(&mut self){
+        use crate::FAILURE_FORCED_DELAY_MILLISECONDS;
+        // TODO block for the time defined in the constant
+        // DESIGN allow only a couple of failures per power cycle? Similarly to the FIDO2 PIN
     }
 }
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -15,7 +15,7 @@ use trussed::{
     types::{KeyId, Location, PathBuf},
 };
 
-use crate::{assertfn, command, Command, oath, state::{CommandState, State}};
+use crate::{ensure, command, Command, oath, state::{CommandState, State}};
 use crate::command::VerifyCode;
 use crate::oath::Kind;
 
@@ -174,9 +174,9 @@ where
     fn inner_respond<const C: usize, const R: usize>(&mut self, command: &iso7816::Command<C>, reply: &mut Data<R>) -> Result
     {
         let class = command.class();
-        assertfn(class.chain().last_or_only(), Status::CommandChainingNotSupported)?;
-        assertfn(class.secure_messaging().none(), Status::SecureMessagingNotSupported)?;
-        assertfn(class.channel() == Some(0), Status::ClassNotSupported)?;
+        ensure(class.chain().last_or_only(), Status::CommandChainingNotSupported)?;
+        ensure(class.secure_messaging().none(), Status::SecureMessagingNotSupported)?;
+        ensure(class.channel() == Some(0), Status::ClassNotSupported)?;
 
         // parse Iso7816Command as PivCommand
         let command: Command = command.try_into()?;
@@ -792,7 +792,6 @@ where
         );
         // load-bump counter
         let filename = self.filename_for_label(credential.label);
-        // TODO: use try_syscall
         try_syscall!(self.trussed.write_file(
                         Location::Internal,
                         filename,

--- a/src/command.rs
+++ b/src/command.rs
@@ -285,7 +285,7 @@ impl<'a> flexiber::Decodable<'a> for Properties {
         let two_bytes: [u8; 2] = decoder.decode()?;
         let [tag, properties] = two_bytes;
         use flexiber::Tagged;
-        assert_eq!(flexiber::Tag::try_from(tag).unwrap(), Self::tag());
+        assertfn(flexiber::Tag::try_from(tag).unwrap() == Self::tag(), flexiber::ErrorKind::Failed)?;
         Ok(Properties(properties))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,7 @@ pub const UP_TIMEOUT_MILLISECONDS: u32 = 15 * 1000;
 //     U2F_YUBICO = b'\xa0\x00\x00\x05\x27\x10\x02'  # Yubico - No longer used
 
 
-type Result = iso7816::Result<()>;
-
-fn assertfn(cond: bool, err: iso7816::Status) -> Result{
+fn assertfn<T>(cond: bool, err: T) ->  core::result::Result<(), T> {
     match cond {
         true => Ok(()),
         false => Err(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub const YUBICO_OATH_AID: &[u8] = &hex!("A000000527 2101");// 01");
 
 /// This constant defines timeout for the regular UP confirmation
 pub const UP_TIMEOUT_MILLISECONDS: u32 = 15 * 1000;
+pub const FAILURE_FORCED_DELAY_MILLISECONDS: u32 = 1 * 1000;
 
 // class AID(bytes, Enum):
 //     OTP = b'\xa0\x00\x00\x05\x27 \x20\x01'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub const UP_TIMEOUT_MILLISECONDS: u32 = 15 * 1000;
 //     U2F_YUBICO = b'\xa0\x00\x00\x05\x27\x10\x02'  # Yubico - No longer used
 
 
-fn assertfn<T>(cond: bool, err: T) ->  core::result::Result<(), T> {
+fn ensure<T>(cond: bool, err: T) ->  core::result::Result<(), T> {
     match cond {
         true => Ok(()),
         false => Err(err)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,3 +32,13 @@ pub const UP_TIMEOUT_MILLISECONDS: u32 = 15 * 1000;
 //     PIV = b'\xa0\x00\x00\x03\x08'
 //     U2F = b'\xa0\x00\x00\x06\x47\x2f\x00\x01'  # Official
 //     U2F_YUBICO = b'\xa0\x00\x00\x05\x27\x10\x02'  # Yubico - No longer used
+
+
+type Result = iso7816::Result<()>;
+
+fn assertfn(cond: bool, err: iso7816::Status) -> Result{
+    match cond {
+        true => Ok(()),
+        false => Err(err)
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -94,12 +94,12 @@ impl State {
         let result = f(trussed, &mut state);
 
         // 3. Always write it back
-        syscall!(trussed.write_file(
+        try_syscall!(trussed.write_file(
             Location::Internal,
             PathBuf::from(Self::FILENAME),
             postcard_serialize_bytes(&state).unwrap(),
             None,
-        ));
+        )).map_err(|_| Status::NotEnoughMemory)?;
 
         // 4. Return whatever
         result


### PR DESCRIPTION
Add initial fuzzing support and fixes found during its executions.

Corpus generated with the pynitrokey API tests (not included here). Each input file contains single command only at this point. No new errors found after 20 minutes, with 11 jobs set. A fork of Flexiber was used, which had the crashing `todo()` replaced with returning Error code.

Future work / to discuss:
- [ ] might be worth to run it longer, or in CI
- [ ] extend the corpus to have more commands - Select, Validate, CalculateAll, SendRemaining
- [x] ~disable not tested commands (as mentioned)~ skipped
- [x] add coverage report generation
- [ ] extend the corpus to run multiple commands at a time
- [ ] dockerize/reuse fuzz setup
- [x] something better than `assertfn` ?


Inspired by the opcard-rs [fuzzing implementation](https://github.com/Nitrokey/opcard-rs/tree/main/fuzz).

Fixes #8 