### PR TITLE
Multipacket handling for credentials listing and other improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,13 @@ pretty_env_logger = "0.4.0"
 
 [features]
 default = ["apdu-dispatch"]
-devel = ["apdu-dispatch", "log-all", "delog/std-log"]
+devel = ["apdu-dispatch", "log-all", "delog/std-log", "devel-counters", "devel-ctaphid-bug"]
+
+# Count accesses to the read-only and read-write persistence storage
+devel-counters = []
+
+# Account ctaphid bug about 3072 buffer size. To be removed once fixed.
+devel-ctaphid-bug = []
 
 # Allow to use application over CTAPHID interface
 ctaphid = ["ctaphid-dispatch", "usbd-ctaphid"]

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -638,14 +638,17 @@ where
             return Err(Status::ConditionsOfUseNotSatisfied);
         }
         debug_now!("clearing password/key");
-        if let Some(key) = self.state.try_persistent_read_write(&mut self.trussed, |_, state| {
-            let existing_key = state.authorization_key;
-            state.authorization_key = None;
-            Ok(existing_key)
-        }).map_err(|_| Status::NotEnoughMemory)?
-            {
-                syscall!(self.trussed.delete(key));
-            }
+        if let Some(key) = self
+            .state
+            .try_persistent_read_write(&mut self.trussed, |_, state| {
+                let existing_key = state.authorization_key;
+                state.authorization_key = None;
+                Ok(existing_key)
+            })
+            .map_err(|_| Status::NotEnoughMemory)?
+        {
+            syscall!(self.trussed.delete(key));
+        }
         Ok(())
     }
 
@@ -745,10 +748,12 @@ where
         .key;
 
         debug_now!("storing password/key");
-        self.state.try_persistent_read_write(&mut self.trussed, |_, state| {
-            state.authorization_key = Some(key);
-            Ok(())
-        }).map_err(|_| Status::NotEnoughMemory)?;
+        self.state
+            .try_persistent_read_write(&mut self.trussed, |_, state| {
+                state.authorization_key = Some(key);
+                Ok(())
+            })
+            .map_err(|_| Status::NotEnoughMemory)?;
 
         // pub struct SetPassword<'l> {
         //     pub kind: oath::Kind,

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -150,7 +150,7 @@ where
     ) -> Result {
         let no_authorization_needed = self
             .state
-            .persistent(&mut self.trussed, |_, state| !state.password_set());
+            .persistent_read_only(&mut self.trussed, |_, state| !state.password_set());
 
         // TODO: abstract out this idea to make it usable for all the PIV security indicators
 
@@ -236,7 +236,7 @@ where
 
         let state = self
             .state
-            .persistent(&mut self.trussed, |_, state| state.clone());
+            .persistent_read_only(&mut self.trussed, |_, state| state.clone());
         let answer_to_select = AnswerToSelect::new(state.salt);
 
         let data: heapless::Vec<u8, 128> = if state.password_set() {
@@ -576,7 +576,7 @@ where
 
         if let Some(key) = self
             .state
-            .persistent(&mut self.trussed, |_, state| state.authorization_key)
+            .persistent_read_only(&mut self.trussed, |_, state| state.authorization_key)
         {
             debug_now!("key set: {:?}", key);
 
@@ -638,7 +638,7 @@ where
             return Err(Status::ConditionsOfUseNotSatisfied);
         }
         debug_now!("clearing password/key");
-        if let Some(key) = self.state.persistent(&mut self.trussed, |_, state| {
+        if let Some(key) = self.state.persistent_read_write(&mut self.trussed, |_, state| {
             let existing_key = state.authorization_key;
             state.authorization_key = None;
             existing_key
@@ -744,7 +744,7 @@ where
         .key;
 
         debug_now!("storing password/key");
-        self.state.persistent(&mut self.trussed, |_, state| {
+        self.state.persistent_read_write(&mut self.trussed, |_, state| {
             state.authorization_key = Some(key)
         });
 

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -335,8 +335,10 @@ where
         reply.push((credential.label.len() + 1) as u8)?;
         reply.push(oath::combine(credential.kind, credential.algorithm))?;
         reply.extend_from_slice(&credential.label).map_err(|_| 0)?;
-        #[cfg(feature = "devel")]
+        #[cfg(feature = "devel-ctaphid-bug")]
         if reply.len() > 3072 {
+            // Finish early due to the usbd-ctaphid bug, which panics on bigger buffers than this
+            // FIXME Remove once fixed
             return Err(1);
         }
         Ok(())

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -727,9 +727,10 @@ where
         }
 
         info_now!("injecting the key");
-        let tmp_key = syscall!(self
+        let tmp_key = try_syscall!(self
             .trussed
             .unsafe_inject_shared_key(key, Location::Volatile,))
+        .map_err(|_| Status::NotEnoughMemory)?
         .key;
 
         let verification = syscall!(self.trussed.sign_hmacsha1(tmp_key, challenge)).signature;

--- a/src/command.rs
+++ b/src/command.rs
@@ -30,6 +30,8 @@ pub enum Command<'l> {
     Validate(Validate<'l>),
     /// Reverse HOTP validation
     VerifyCode(VerifyCode<'l>),
+    /// Send remaining data in the buffer
+    SendRemaining,
 }
 
 /// TODO: change into enum
@@ -491,6 +493,7 @@ impl<'l, const C: usize> TryFrom<&'l iso7816::Command<C>> for Command<'l> {
                 (0x00, oath::Instruction::VerifyCode, 0x00, 0x00) => {
                     Self::VerifyCode(VerifyCode::try_from(data)?)
                 }
+                (0x00, oath::Instruction::SendRemaining, 0x00, 0x00) => Self::SendRemaining,
                 _ => return Err(Status::InstructionNotSupportedOrInvalid),
             })
         }

--- a/src/encrypted_container.rs
+++ b/src/encrypted_container.rs
@@ -195,7 +195,7 @@ impl EncryptedDataContainer {
         let encrypted_serialized_credential = EncryptedDataContainer {
             data: ciphertext,
             nonce: encryption_results.nonce.try_convert_into().unwrap(), // should always be 12 bytes
-            tag: encryption_results.tag.try_convert_into().unwrap(),  // should always be 16 bytes
+            tag: encryption_results.tag.try_convert_into().unwrap(), // should always be 16 bytes
         };
         Ok(encrypted_serialized_credential)
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -21,7 +21,9 @@ pub struct State {
     // temporary "state", to be removed again
     // pub hack: Hack,
     // trussed: RefCell<Trussed<S>>,
+    #[cfg(feature = "devel")]
     counter_read_write: u32,
+    #[cfg(feature = "devel")]
     counter_read_only: u32,
 }
 
@@ -195,8 +197,10 @@ impl State {
     {
         let mut state: Persistent = Self::get_persistent_or_default(trussed);
 
-        self.counter_read_write += 1;
-        debug_now!("Getting the state RW {}", self.counter_read_write);
+        #[cfg(feature = "devel")]{
+            self.counter_read_write += 1;
+            debug_now!("Getting the state RW {}", self.counter_read_write);
+        }
         // 2. Let the app read or modify the state
         let x = f(trussed, &mut state);
 
@@ -221,8 +225,10 @@ impl State {
     {
         let state: Persistent = Self::get_persistent_or_default(trussed);
 
-        self.counter_read_only += 1;
-        debug_now!("Getting the state RO {}", self.counter_read_only);
+        #[cfg(feature = "devel")]{
+            self.counter_read_only += 1;
+            debug_now!("Getting the state RO {}", self.counter_read_only);
+        }
         // 2. Let the app read the state
         let x = f(trussed, &state);
         x

--- a/src/state.rs
+++ b/src/state.rs
@@ -114,16 +114,15 @@ impl State {
         T: trussed::Client + trussed::client::Chacha8Poly1305,
     {
         // Try to read it
-        let maybe_encryption_key = self.persistent_read_only(trussed, |_, state| {
-            state.encryption_key
-        });
+        let maybe_encryption_key =
+            self.persistent_read_only(trussed, |_, state| state.encryption_key);
 
         // Generate encryption key
         let encryption_key = match maybe_encryption_key {
             Some(e) => e,
             None => self.try_persistent_read_write(trussed, |trussed, state| {
                 state.get_or_generate_encryption_key(trussed)
-            })?
+            })?,
         };
         Ok(encryption_key)
     }
@@ -171,7 +170,8 @@ impl State {
     {
         let mut state: Persistent = Self::get_persistent_or_default(trussed);
 
-        #[cfg(feature = "devel")]{
+        #[cfg(feature = "devel")]
+        {
             self.counter_read_write += 1;
             debug_now!("Getting the state RW {}", self.counter_read_write);
         }
@@ -194,12 +194,13 @@ impl State {
         trussed: &mut T,
         f: impl FnOnce(&mut T, &Persistent) -> X,
     ) -> X
-        where
-            T: trussed::Client + trussed::client::Chacha8Poly1305,
+    where
+        T: trussed::Client + trussed::client::Chacha8Poly1305,
     {
         let state: Persistent = Self::get_persistent_or_default(trussed);
 
-        #[cfg(feature = "devel")]{
+        #[cfg(feature = "devel")]
+        {
             self.counter_read_only += 1;
             debug_now!("Getting the state RO {}", self.counter_read_only);
         }

--- a/src/state.rs
+++ b/src/state.rs
@@ -21,9 +21,11 @@ pub struct State {
     // temporary "state", to be removed again
     // pub hack: Hack,
     // trussed: RefCell<Trussed<S>>,
-    #[cfg(feature = "devel")]
+    // Count read-write access to the persistence storage. Development only.
+    #[cfg(feature = "devel-counters")]
     counter_read_write: u32,
-    #[cfg(feature = "devel")]
+    // Count read-only access to the persistence storage. Development only.
+    #[cfg(feature = "devel-counters")]
     counter_read_only: u32,
 }
 
@@ -173,7 +175,7 @@ impl State {
     {
         let mut state: Persistent = Self::get_persistent_or_default(trussed);
 
-        #[cfg(feature = "devel")]
+        #[cfg(feature = "devel-counters")]
         {
             self.counter_read_write += 1;
             debug_now!("Getting the state RW {}", self.counter_read_write);
@@ -202,7 +204,7 @@ impl State {
     {
         let state: Persistent = Self::get_persistent_or_default(trussed);
 
-        #[cfg(feature = "devel")]
+        #[cfg(feature = "devel-counters")]
         {
             self.counter_read_only += 1;
             debug_now!("Getting the state RO {}", self.counter_read_only);


### PR DESCRIPTION
Changes:
- Use smaller buffers for the EncryptedDataContainer crypto fields, to save stack.
- Handle multipacket responses, specifically for listing the credentials.
- Use read-only state access where possible, to limit writes.


Fixes https://github.com/Nitrokey/oath-authenticator/issues/19
Fixes https://github.com/Nitrokey/oath-authenticator/issues/14