### PR TITLE
Set default location to the external memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ pretty_env_logger = "0.4.0"
 
 [features]
 default = ["apdu-dispatch"]
-devel = ["apdu-dispatch", "log-all", "delog/std-log", "devel-counters", "devel-ctaphid-bug"]
+devel = ["apdu-dispatch", "log-all", "delog/std-log", "devel-counters", "devel-ctaphid-bug", "devel-location-internal"]
 
 # Count accesses to the read-only and read-write persistence storage
 devel-counters = []
@@ -43,6 +43,9 @@ ctaphid = ["ctaphid-dispatch", "usbd-ctaphid"]
 
 # Do not run the actual encryption of the credentials.
 no-encrypted-credentials = []
+
+# Set the default files location to the internal memory. Useful for debugging.
+devel-location-internal = []
 
 log-all = []
 log-none = []

--- a/src/authenticator.rs
+++ b/src/authenticator.rs
@@ -273,7 +273,7 @@ where
         // If you lost your PIN, you wouldn't be able to reset otherwise.
 
         debug_now!(":: reset - delete all keys");
-        try_syscall!(self.trussed.delete_all(Location::Internal))
+        try_syscall!(self.trussed.delete_all(crate::DEFAULT_LOCATION))
             .map_err(|_| Status::NotEnoughMemory)?;
 
         debug_now!(":: reset - delete all files");
@@ -281,7 +281,7 @@ where
         // NB: This deletes state.bin too, so it removes a possibly set password and encryption key.
         try_syscall!(self
             .trussed
-            .remove_dir_all(Location::Internal, PathBuf::new()))
+            .remove_dir_all(crate::DEFAULT_LOCATION, PathBuf::new()))
         .map_err(|_| Status::NotEnoughMemory)?;
 
         self.state.runtime.reset();
@@ -317,7 +317,7 @@ where
 
             let _filename = self.filename_for_label(label);
             let _deletion_result =
-                try_syscall!(self.trussed.remove_file(Location::Internal, _filename));
+                try_syscall!(self.trussed.remove_file(crate::DEFAULT_LOCATION, _filename));
             debug_now!(
                 "Delete credential with filename {}, result: {:?}",
                 &self.filename_for_label(label),
@@ -370,7 +370,7 @@ where
             // To avoid creating additional buffer for the unfit data
             // we will rewind the state and restart from there accordingly
             let first_file = try_syscall!(self.trussed.read_dir_files_first(
-                Location::Internal,
+                crate::DEFAULT_LOCATION,
                 Self::credential_directory(),
                 None
             ))
@@ -455,7 +455,7 @@ where
         let raw_key = register.credential.secret;
         let key_handle = try_syscall!(self
             .trussed
-            .unsafe_inject_shared_key(raw_key, Location::Internal))
+            .unsafe_inject_shared_key(raw_key, crate::DEFAULT_LOCATION))
         .map_err(|_| Status::NotEnoughMemory)?
         .key;
         // info!("new key handle: {:?}", key_handle);
@@ -478,7 +478,7 @@ where
             try_syscall!(self.trussed.delete(credential.secret)).ok();
             // 2. Try to delete the empty file, ignore errors
             let filename = self.filename_for_label(&credential.label);
-            try_syscall!(self.trussed.remove_file(Location::Internal, filename)).ok();
+            try_syscall!(self.trussed.remove_file(crate::DEFAULT_LOCATION, filename)).ok();
             // 3. Return the original error
             write_res?
         }
@@ -529,7 +529,7 @@ where
         }
 
         let maybe_credential_enc = syscall!(self.trussed.read_dir_files_first(
-            Location::Internal,
+            crate::DEFAULT_LOCATION,
             Self::credential_directory(),
             None
         ))
@@ -811,7 +811,7 @@ where
         // all-right, we have a new password to set
         let key = try_syscall!(self
             .trussed
-            .unsafe_inject_shared_key(key, Location::Internal,))
+            .unsafe_inject_shared_key(key, crate::DEFAULT_LOCATION,))
         .map_err(|_| Status::NotEnoughMemory)?
         .key;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,9 @@ extern crate hex_literal;
 extern crate alloc;
 
 pub mod authenticator;
+
 pub use authenticator::Authenticator;
+use trussed::types::Location;
 pub mod calculate;
 pub mod command;
 pub use command::Command;
@@ -28,6 +30,11 @@ pub const YUBICO_OATH_AID: &[u8] = &hex!("A000000527 2101"); // 01");
 /// This constant defines timeout for the regular UP confirmation
 pub const UP_TIMEOUT_MILLISECONDS: u32 = 15 * 1000;
 pub const FAILURE_FORCED_DELAY_MILLISECONDS: u32 = 1000;
+
+#[cfg(feature = "devel-location-internal")]
+pub const DEFAULT_LOCATION: Location = Location::Internal;
+#[cfg(not(feature = "devel-location-internal"))]
+pub const DEFAULT_LOCATION: Location = Location::External;
 
 // class AID(bytes, Enum):
 //     OTP = b'\xa0\x00\x00\x05\x27 \x20\x01'


### PR DESCRIPTION
Set default location to the external memory.

Based on the PR #24. Relevant commit: https://github.com/Nitrokey/oath-authenticator/pull/25/commits/260ef53b5bba850338fdc1225feee4d1937c61e4.