### PR TITLE
Dependency and clippy fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ trussed = { version = "0.1", features = ["clients-3"] }
 
 # ctaphid
 ctaphid-dispatch = { version = "0.1", optional = true }
-usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", optional = true}
+usbd-ctaphid = "0.1.0"
 
 [dev-dependencies]
 log = { version = "0.4.14", default-features = false }
@@ -72,4 +72,3 @@ flexiber = { git = "https://github.com/Nitrokey/flexiber", rev = "0.1.1.nitrokey
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.1-nitrokey-1" }
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
-usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", tag = "0.1.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,4 +72,4 @@ flexiber = { git = "https://github.com/Nitrokey/flexiber", rev = "0.1.1.nitrokey
 apdu-dispatch = { git = "https://github.com/Nitrokey/apdu-dispatch", tag = "v0.1.1-nitrokey-1" }
 littlefs2 = { git = "https://github.com/Nitrokey/littlefs2", tag = "v0.3.2-nitrokey-1" }
 trussed = { git = "https://github.com/Nitrokey/trussed", tag = "v0.1.0-nitrokey-4" }
-usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid"}
+usbd-ctaphid = { git = "https://github.com/trussed-dev/usbd-ctaphid", tag = "0.1.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ trussed = { version = "0.1", features = ["clients-3"] }
 
 # ctaphid
 ctaphid-dispatch = { version = "0.1", optional = true }
-usbd-ctaphid = "0.1.0"
+usbd-ctaphid = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 log = { version = "0.4.14", default-features = false }

--- a/src/oath.rs
+++ b/src/oath.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 pub const HMAC_MINIMUM_KEY_SIZE: usize = 14;
 
+#[allow(unused)]
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Tag {


### PR DESCRIPTION
Dependency and clippy fixes:
- set `usbd-ctaphid` source to cargo
- silence unused enum warning